### PR TITLE
Add lower bound on template-haskell to fix build on GHC 7.10

### DIFF
--- a/rethinkdb-client-driver.cabal
+++ b/rethinkdb-client-driver.cabal
@@ -44,7 +44,7 @@ library
                       , old-locale
                       , scientific
                       , stm
-                      , template-haskell
+                      , template-haskell >= 2.11.0.0
                       , text
                       , time >= 1.4
                       , unordered-containers


### PR DESCRIPTION
Another solution is to add some CPP since my change requires to install a new template-haskell version on GHC 7.10, which can sometimes be problematic.
